### PR TITLE
Fix CloudBand class and update package to version 1.2.1

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2013, Romain Pilon
+Copyright (c) 2024, Romain Pilon
 All rights reserved.
 
 

--- a/config/config_cbworkflow_northPacific.yml
+++ b/config/config_cbworkflow_northPacific.yml
@@ -42,7 +42,7 @@ parameters_file: './cloudbandPy/parameters/parameters_northhemisphere.yml'
 saved_dirpath: './cloud_band_files' # directory where files will be saved
 
 save_dailyvar: False # save daily mean of the input variable
-save_listcloudbands: False # Pickle bin files of list containing lists of cloud band (1 list per day)
+save_listcloudbands: True # Pickle bin files of list containing lists of cloud band (1 list per day)
 save_cloudbands_netcdf: True # netCDF4 files containing cloud band masks and cloud band characteristics
 
 # To load pickle bin files saved in saved_dirpath and not load files containing raw data

--- a/config/config_cbworkflow_northernhemisphere.yml
+++ b/config/config_cbworkflow_northernhemisphere.yml
@@ -1,4 +1,4 @@
-# Cloud band detection configuration file for North Pacific basin
+# Cloud band detection configuration file for northern hemisphere
 
 # Compute the inheritance of each cloud band
 run_inheritance_tracking: True
@@ -42,7 +42,7 @@ parameters_file: './cloudbandPy/parameters/parameters_northhemisphere.yml'
 saved_dirpath: './cloud_band_files' # directory where files will be saved
 
 save_dailyvar: False # save daily mean of the input variable
-save_listcloudbands: False # Pickle bin files of list containing lists of cloud band (1 list per day)
+save_listcloudbands: True # Pickle bin files of list containing lists of cloud band (1 list per day)
 save_cloudbands_netcdf: True # netCDF4 files containing cloud band masks and cloud band characteristics
 
 # To load pickle bin files saved in saved_dirpath and not load files containing raw data

--- a/config/config_cbworkflow_southAtlantic.yml
+++ b/config/config_cbworkflow_southAtlantic.yml
@@ -1,4 +1,4 @@
-# Cloud band detection configuration file for South Pacific basin
+# Cloud band detection configuration file for South Atlantic basin
 
 # Compute the inheritance of each cloud band
 run_inheritance_tracking: True
@@ -42,7 +42,7 @@ parameters_file: './cloudbandPy/parameters/parameters_southhemisphere.yml'
 saved_dirpath: './cloud_band_files' # directory where files will be saved
 
 save_dailyvar: False # save daily mean of the input variable
-save_listcloudbands: False # Pickle bin files of list containing lists of cloud band (1 list per day)
+save_listcloudbands: True # Pickle bin files of list containing lists of cloud band (1 list per day)
 save_cloudbands_netcdf: True # netCDF4 files containing cloud band masks and cloud band characteristics
 
 # To load pickle bin files saved in saved_dirpath and not load files containing raw data

--- a/config/config_cbworkflow_southIndianOcean.yml
+++ b/config/config_cbworkflow_southIndianOcean.yml
@@ -42,7 +42,7 @@ parameters_file: './cloudbandPy/parameters/parameters_southhemisphere.yml'
 saved_dirpath: './cloud_band_files' # directory where files will be saved
 
 save_dailyvar: False # save daily mean of the input variable
-save_listcloudbands: False # Pickle bin files of list containing lists of cloud band (1 list per day)
+save_listcloudbands: True # Pickle bin files of list containing lists of cloud band (1 list per day)
 save_cloudbands_netcdf: True # netCDF4 files containing cloud band masks and cloud band characteristics
 
 # To load pickle bin files saved in saved_dirpath and not load files containing raw data

--- a/config/config_cbworkflow_southPacific.yml
+++ b/config/config_cbworkflow_southPacific.yml
@@ -42,7 +42,7 @@ parameters_file: './cloudbandPy/parameters/parameters_southhemisphere.yml'
 saved_dirpath: './cloud_band_files' # directory where files will be saved
 
 save_dailyvar: False # save daily mean of the input variable
-save_listcloudbands: False # Pickle bin files of list containing lists of cloud band (1 list per day)
+save_listcloudbands: True # Pickle bin files of list containing lists of cloud band (1 list per day)
 save_cloudbands_netcdf: True # netCDF4 files containing cloud band masks and cloud band characteristics
 
 # To load pickle bin files saved in saved_dirpath and not load files containing raw data

--- a/config/config_cbworkflow_southernhemisphere.yml
+++ b/config/config_cbworkflow_southernhemisphere.yml
@@ -1,4 +1,4 @@
-# Cloud band detection configuration file for North Pacific basin
+# Cloud band detection configuration file for southern hemisphere
 
 # Compute the inheritance of each cloud band
 run_inheritance_tracking: True
@@ -42,7 +42,7 @@ parameters_file: './cloudbandPy/parameters/parameters_southhemisphere.yml'
 saved_dirpath: './cloud_band_files' # directory where files will be saved
 
 save_dailyvar: False # save daily mean of the input variable
-save_listcloudbands: False # Pickle bin files of list containing lists of cloud band (1 list per day)
+save_listcloudbands: True # Pickle bin files of list containing lists of cloud band (1 list per day)
 save_cloudbands_netcdf: True # netCDF4 files containing cloud band masks and cloud band characteristics
 
 # To load pickle bin files saved in saved_dirpath and not load files containing raw data

--- a/runscripts/run_multiyear_cb_detection_to_file.bash
+++ b/runscripts/run_multiyear_cb_detection_to_file.bash
@@ -77,7 +77,7 @@ create_tmp_config() {
 main() {
     tmpdir_config=~/tmp
     [[ ! -d "${tmpdir_config}" ]] && mkdir "${tmpdir_config}"
-    declare -a domains=("southPacific") # "northPacific" "southIndianOcean" "southAtlantic" "southernhemisphere" "northernhemisphere")
+    declare -a domains=("southPacific" "northPacific" "southIndianOcean" "southAtlantic" "southernhemisphere" "northernhemisphere")
     years=($(seq $YEAR_START $YEAR_END))
     echo $years
     local year="${years[${SLURM_ARRAY_TASK_ID}]}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = cloudbandpy
-version = 1.2.0
+version = 1.2.1
 author = Romain Pilon
 author_email = romain.pilon@gmail.com
 description = A Python package for atmospheric cloud bands detection.

--- a/src/cloudbandpy/cloudband.py
+++ b/src/cloudbandpy/cloudband.py
@@ -13,31 +13,28 @@ class CloudBand(object):
     def __init__(
         self,
         cloud_band_array: np.ndarray,
+        date: np.int32,
         area: float,
         lats: np.ndarray,
         lons: np.ndarray,
-        date: np.int32,
+        angle: np.float32,
+        lon_centroid=np.float16,
+        lat_centroid=np.float16,
         iscloudband: bool = True,
         connected_longitudes: bool = False,
         parents: set[str] = set(),
-        connected2pv: bool = False,
-        connected2eqwave: bool = False,
     ):
         self.cloud_band_array = cloud_band_array
         self.date = date
         self.area = area
-        # return a list, here we've got only one cloud band --> [0]
-        regions_props = measure.regionprops(self.cloud_band_array)[0]
-        # center of ellipse around cloud band
-        self.latloncenter = regions_props.centroid
-        # angle between the minor axis and the horizontal, at the centroid
-        self.angle = (regions_props.orientation * 360) / (2 * np.pi)
+        self.angle = angle
+        self.lon_centroid = lon_centroid
+        self.lat_centroid = lat_centroid
         # Label/id of the cloud band
         self.parents = parents
-        self.connected2pv = connected2pv
-        self.connected2eqwave = connected2eqwave
         # id = "date _ longitude (location)"
-        self.id_ = int(f"{self.date}_{round(self.latloncenter[1])}")
+        # self.id_ = int(f"{self.date}_{round(self.lon_centroid)}")
+        self.id_ = int(f"{self.date}{round(self.lon_centroid % 360):03d}")
         #
         self.lats = lats
         self.lons = lons
@@ -58,10 +55,13 @@ class CloudBand(object):
             data = pickle.load(f)
             return cls(
                 data["cloud_band_array"],
+                data["date"],
                 data["area"],
                 data["lats"],
                 data["lons"],
-                data["date"],
+                data["angle"],
+                data["lon_centroid"],
+                data["lat_centroid"],
                 data["iscloudband"],
                 data["connected_longitudes"],
                 data["parents"],
@@ -77,12 +77,15 @@ class CloudBand(object):
         """
         return cls(
             d["cloud_band_array"],
+            d["date"],
             d["area"],
             d["lats"],
             d["lons"],
-            d["date"],
-            d["connected_longitudes"],
+            d["angle"],
+            d["lon_centroid"],
+            d["lat_centroid"],
             d["iscloudband"],
+            d["connected_longitudes"],
             d["parents"],
         )
 
@@ -97,12 +100,15 @@ class CloudBand(object):
              pickle.dump(
                 {
                     "cloud_band_array": self.cloud_band_array,
+                    "date": self.date,
                     "area": self.area,
                     "lats": self.lats,
                     "lons": self.lons,
-                    "date": self.date_number,
-                    "connected_longitudes": self.connected_longitudes,
+                    "angle": self.angle,
+                    "lon_centroid": self.lon_centroid,
+                    "lat_centroid": self.lat_centroid,
                     "iscloudband": self.iscloudband,
+                    "connected_longitudes": self.connected_longitudes,
                     "parents": self.parents,
                 },
                 f,
@@ -116,12 +122,15 @@ class CloudBand(object):
         """
         return {
             "cloud_band_array": self.cloud_band_array,
+            "date": self.date,
             "area": self.area,
             "lats": self.lats,
             "lons": self.lons,
-            "date": self.date,
-            "connected_longitudes": self.connected_longitudes,
+            "angle": self.angle,
+            "lon_centroid": self.lon_centroid,
+            "lat_centroid": self.lat_centroid,
             "iscloudband": self.iscloudband,
+            "connected_longitudes": self.connected_longitudes,
             "parents": self.parents,
         }
 

--- a/src/cloudbandpy/io_utilities.py
+++ b/src/cloudbandpy/io_utilities.py
@@ -368,8 +368,8 @@ def write_cloud_bands_to_netcdf(
         for object_index, cloud_band in enumerate(cbdays):
             # date_number[day_index, object_index] = cloud_band.date_number
             area[day_index, object_index] = cloud_band.area
-            latcenters[day_index, object_index] = cloud_band.latloncenter[0]
-            loncenters[day_index, object_index] = cloud_band.latloncenter[1]
+            latcenters[day_index, object_index] = cloud_band.lat_centroid
+            loncenters[day_index, object_index] = cloud_band.lon_centroid
             angle[day_index, object_index] = cloud_band.angle
             cbid[day_index, object_index] = cloud_band.id_
 


### PR DESCRIPTION
This pull request includes critical fixes and updates to the CloudBand class and associated configurations:

- Fixed how longitude and latitude for cloud band centroids are set in the code.
- Revised the method for generating unique IDs for cloud bands to ensure accuracy and consistency.
- Added new variables to the `CloudBand` class and its class methods for better functionality and usability.
- Updated the package version to `1.2.1` to reflect these changes.
- Fixed minor typos in configuration files.

Note: Files created with version `1.2.0` or earlier will not be compatible with version `1.2.1`. This is due to changes in how cloud band centroids are stored and the updated ID generation method. Users are advised to regenerate or update their files accordingly.

These updates improve the robustness of the `CloudBand` class and ensure the package aligns with its intended functionality. All updates have been tested.